### PR TITLE
ボタン/アラート表示

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -14,17 +14,21 @@ class LinebotController < ApplicationController
   end
 
   def callback
-    message = {
-      type: 'text',
-      text: 'アルバイトの更新がありました!以下サイトからご確認に方よろしくお願いします。
-      https://work-event.herokuapp.com/events'
-    }
-    provider = User.where(provider: "line")
-    provider.each do|values|
-      user_id = values[:uid]
-      response = client.push_message(user_id, message)
+    if User.guest
+      redirect_to welcome_home_path, alert: "ゲストユーザーは送信ができません。"
+    else
+      message = {
+        type: 'text',
+        text: 'アルバイトの更新がありました!以下サイトからご確認に方よろしくお願いします。
+        https://work-event.herokuapp.com/events'
+      }
+      provider = User.where(provider: "line")
+      provider.each do|values|
+        user_id = values[:uid]
+        response = client.push_message(user_id, message)
+      end
+      redirect_to welcome_home_path, notice: "送信しました"
     end
-    redirect_to welcome_home_path, notice: "送信しました"
   end
 
 end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -14,9 +14,7 @@ class LinebotController < ApplicationController
   end
 
   def callback
-    if User.guest
-      redirect_to welcome_home_path, alert: "ゲストユーザーは送信ができません。"
-    else
+    if current_user.provider == "line"
       message = {
         type: 'text',
         text: 'アルバイトの更新がありました!以下サイトからご確認に方よろしくお願いします。
@@ -28,6 +26,8 @@ class LinebotController < ApplicationController
         response = client.push_message(user_id, message)
       end
       redirect_to welcome_home_path, notice: "送信しました"
+    else
+      redirect_to welcome_home_path, alert: "ゲストユーザーは送信ができません。"
     end
   end
 

--- a/app/views/layouts/_event-status.html.erb
+++ b/app/views/layouts/_event-status.html.erb
@@ -1,9 +1,9 @@
 <div class="col-4">
     <% if @event.created_by?(current_user) %>
       <%= link_to "編集", edit_event_path(@event), class: "btn btn-info btn-lg btn-block" %>
-      <%= link_to "削除", event_path(@event), class: "btn btn-danger btn-lg btn-block", method: :delete, date: { confirm: "本当に削除しますか"} %>
+      <%= link_to "削除", event_path(@event),  method: :delete, data: { confirm: "投稿を削除して大丈夫ですか？" }, class: "btn btn-danger btn-lg btn-block" %>
       
-      <%= link_to "送る", callback_path(@event), class: "btn  btn-lg btn-block btn-success", method: :post %>
+      <%= link_to "送る", callback_path(@event), method: :post, data: { confirm: "送信しますか？" }, class: "btn  btn-lg btn-block btn-success" %>
       
     <% end %>
     <% if user_signed_in? == @ticket.nil? %>

--- a/app/views/retirements/new.html.erb
+++ b/app/views/retirements/new.html.erb
@@ -11,4 +11,4 @@
 </ul>
 <!-- / -->
 <hr>
-<%= link_to "退会する", retirements_path, method: :post, remote: true, class: "btn btn-danger", date: {confirm: "本当に退会しますか"}%>
+<%= link_to "退会する", retirements_path, method: :post, data: {confirm: "本当に退会しますか"}, class: "btn btn-danger"%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,7 +32,7 @@
           </div>
 
           <li class="nav-item active">
-            <%= link_to "ログアウト",  new_retirements_path, class: "nav-link"%>
+            <%= link_to "ログアウト",  new_retirements_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-link"%>
           </li>
         <% else %>
           <li class="nav-item active">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,7 +32,7 @@
           </div>
 
           <li class="nav-item active">
-            <%= link_to "ログアウト",  new_retirements_path, method: :delete, data: { confirm: "ログアウトしますか？" }, class: "nav-link"%>
+            <%= link_to "ログアウト",  new_retirements_path,  class: "nav-link"%>
           </li>
         <% else %>
           <li class="nav-item active">

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,11 +7,17 @@
         <div class="top-content"><img class="img-fluid" src="/assets/roof_log.png" alt=""></div>
         <div class="sign-box">
           <div class="sign-content">
+          <% if user_signed_in? %>
+          <div class="text-center text-lg-start">
+              <%= link_to '早速募集をしてみよう！！', new_event_path, class: 'btn btn-outline-danger rounded-pill'%>
+              </div>
+          <% else %>
             <div class="text-center text-lg-start">
               <%= link_to "今すぐはじめる", new_user_registration_path, class: 'btn btn-outline-dark rounded-pill' %>
               <%= link_to "LINEでログイン", user_line_omniauth_authorize_path, method: :post, class: 'btn btn-outline-success rounded-pill' %>
               <%= link_to "ゲストログイン", users_guest_sign_in_path, method: :post, class: 'btn btn-outline-danger rounded-pill' %>
             </div>
+          <% end %>
           </div>
         </div>
         <!-- /.sign-box -->


### PR DESCRIPTION
## 概要
削除・ログアウト・送信のアクションにアラートをつける。
送信はゲストログインはできないようにする。
ログイン後に再度ログインボタンが表示されていたので、投稿ボタンを表示するように変更
